### PR TITLE
Minor syntax highlighting changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,10 @@
 A Sublime syntax-definition for Smali. Just check the repo out to your Sublime Text 2 packages directory, and you should be good to go. I wrote this at 3:00 AM, so stuff is probably missing, and definitely buggy.
 
+Installation:
+* Locate Sublime's Packages directory
+  Command + Shift + P, "Preferences: Browse Packages"
+* Create a directory called Smali
+* Copy smali.tmlanguage into Smali directory
+* Sublime should open the next Smali file with highlighting and does not need to be restarted
+
 ![](http://i.imgur.com/RrAmA.png "My money shot")

--- a/smali.tmlanguage
+++ b/smali.tmlanguage
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
+<plist version="1.1">
 <dict>
 	<key>name</key>
 	<string>Smali</string>
@@ -18,13 +18,13 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>^(#|//).*?$</string>
+			<string>^[ ]*#.*?$</string>
 			<key>name</key>
 			<string>comment.line.smali</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(v\d|p\d)</string>
+			<string>(v|p)([123456789]+\d*|0)</string>
 			<key>name</key>
 			<string>variable.parameter.smali</string>
 		</dict>


### PR DESCRIPTION
Allow comments to start with space
Lines starting with // are not legal comments in Smali
Variable names must be 0, or start with non-zero followed by zero or more digits
Update readme with installation instructions
